### PR TITLE
Fix some ussyes with the AsyncLock, AsyncLockHelper and MutexHelper classes

### DIFF
--- a/JMWToolkit.Tests/JMWToolkit.Tests.csproj
+++ b/JMWToolkit.Tests/JMWToolkit.Tests.csproj
@@ -1,23 +1,21 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\JMWToolkit\JMWToolkit.csproj" />
   </ItemGroup>
-
 </Project>

--- a/JMWToolkit/AsyncLock.cs
+++ b/JMWToolkit/AsyncLock.cs
@@ -31,7 +31,8 @@ public class AsyncLock
 
         while (!lockObtained)
         {
-            // Try and get the mutex, if we cannot then go back to waiting for the 
+            // Try and get the mutex, if we cannot then go back to waiting for it to
+            // be released.
             if (helper.Wait(TimeSpan.Zero))
             {
                 if (!_lockIsHeld)

--- a/JMWToolkit/AsyncLock.cs
+++ b/JMWToolkit/AsyncLock.cs
@@ -1,12 +1,5 @@
-﻿/*
- * Copyright (c) 2023, jmwileydev@gmail.com
-All rights reserved.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree. 
-*/
-using System;
-using System.ServiceModel.Channels;
+﻿using System;
+using System.Diagnostics;
 using System.Threading;
 
 namespace JMWToolkit;
@@ -23,15 +16,23 @@ public class AsyncLock
     private bool _lockIsHeld = false;
     private readonly TimeSpan _infiniteWait = new(0, 0, 0, 0, -1);
 
+    public AsyncLock(bool initiallyLocked = false)
+    {
+        if (initiallyLocked)
+        {
+            _lockIsHeld = true;
+        }
+    }
+
     public bool Wait()
     {
         bool lockObtained = false;
-
         using MutexHelper helper = new(_mutex, false);
 
         while (!lockObtained)
         {
-            helper.Wait();
+            // Try and get the mutex, if we cannot then go back to waiting for the 
+            if (helper.Wait(TimeSpan.Zero))
             {
                 if (!_lockIsHeld)
                 {
@@ -39,6 +40,8 @@ public class AsyncLock
                     lockObtained = true;
                     break;
                 }
+
+                helper.Release();
             }
 
             // If we get here then the mutex is held and we need to wait for it to be
@@ -62,25 +65,24 @@ public class AsyncLock
                 "Negative timeout's are not allowed as a Wait time, unless it is -1 which implies Infinite");
         }
 
-        var startTime = DateTime.Now;
-        using MutexHelper mutexHelper = new(_mutex, false);
+        var stopWatch = new Stopwatch();
+        stopWatch.Start();
+        using MutexHelper helper = new(_mutex, false);
+
         do
         {
-            bool ownsMutex = false;
-
-            ownsMutex = mutexHelper.Wait(timeout);
-            if (!ownsMutex)
+            if (helper.Wait(TimeSpan.Zero))
             {
-                return false;
+                if (!_lockIsHeld)
+                {
+                    _lockIsHeld = true;
+                    return true;
+                }
             }
 
-            if (!_lockIsHeld)
-            {
-                _lockIsHeld = true;
-                return true;
-            }
+            helper.Release();
 
-            timeout -= (DateTime.Now - startTime);
+            timeout -= stopWatch.Elapsed;
             if (timeout > TimeSpan.Zero)
             {
                 if (!_event.WaitOne(timeout))
@@ -88,7 +90,7 @@ public class AsyncLock
                     return false;
                 }
 
-                timeout -= (DateTime.Now - startTime);
+                timeout -= stopWatch.Elapsed;
             }
 
         } while (timeout > TimeSpan.Zero);
@@ -103,12 +105,12 @@ public class AsyncLock
             throw new InvalidOperationException("AsyncLock.Release = The lock is not currently being held");
         }
 
-        using (MutexHelper helper = new(_mutex))
         {
+            using var mutexHelper = new MutexHelper(_mutex);
             _lockIsHeld = false;
         }
 
-        // After we release the lock we can signal any other waiters
+        // After we release the lock we can signal all the other waiters so someone can get the lock
         _event.Set();
     }
 }

--- a/JMWToolkit/AsyncLockHelper.cs
+++ b/JMWToolkit/AsyncLockHelper.cs
@@ -53,6 +53,17 @@ public class AsyncLockHelper : IDisposable
         return _ownsLock;
     }
 
+    public void Release()
+    {
+        if (!_ownsLock)
+        {
+            throw new InvalidOperationException("Release cannot be called if the lock is not owned.");
+        }
+
+        _ownsLock = false;
+        _asyncLock.Release();
+    }
+
     protected virtual void Dispose(bool disposing)
     {
         if (!disposedValue)

--- a/JMWToolkit/AsyncLockHelper.cs
+++ b/JMWToolkit/AsyncLockHelper.cs
@@ -1,11 +1,5 @@
-﻿/*
- * Copyright (c) 2023, jmwileydev@gmail.com
-All rights reserved.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree. 
-*/
-using System;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace JMWToolkit;
 
@@ -24,6 +18,17 @@ public class AsyncLockHelper : IDisposable
         {
             _ownsLock = _asyncLock.Wait();
         }
+    }
+
+    public static async Task<AsyncLockHelper> CreateAsyncLockHelperAsync(AsyncLock asyncLock)
+    {
+        var helper = new AsyncLockHelper(asyncLock, false);
+        await Task<AsyncLockHelper>.Run(() =>
+        {
+            helper.Wait();
+        });
+
+        return helper;
     }
 
     public bool Wait()

--- a/JMWToolkit/JMWToolkit.csproj
+++ b/JMWToolkit/JMWToolkit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -31,11 +31,10 @@
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\LICENSE" Pack="true" PackagePath="" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.421302">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.1" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.2" />
   </ItemGroup>
 </Project>

--- a/JMWToolkit/JMWToolkit.csproj
+++ b/JMWToolkit/JMWToolkit.csproj
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://github.com/jmwileydev/JMWToolkit</PackageProjectUrl>
     <RepositoryUrl>https://github.com/jmwileydev/JMWToolkit</RepositoryUrl>
     <SignAssembly>false</SignAssembly>
-    <Version>1.0.9</Version>
+    <Version>1.0.10</Version>
     <Title>JMWToolkit Dot Net Helpers</Title>
     <License>BSD-2-Clause</License>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/JMWToolkit/JMWToolkit.csproj
+++ b/JMWToolkit/JMWToolkit.csproj
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://github.com/jmwileydev/JMWToolkit</PackageProjectUrl>
     <RepositoryUrl>https://github.com/jmwileydev/JMWToolkit</RepositoryUrl>
     <SignAssembly>false</SignAssembly>
-    <Version>1.0.8</Version>
+    <Version>1.0.9</Version>
     <Title>JMWToolkit Dot Net Helpers</Title>
     <License>BSD-2-Clause</License>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/JMWToolkit/JMWToolkit.sln
+++ b/JMWToolkit/JMWToolkit.sln
@@ -1,11 +1,11 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33513.286
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JMWToolkit", "JMWToolkit.csproj", "{DD5E7976-1758-4BA0-8805-BE87DA882582}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JMWToolkit.Tests", "..\JMWToolkit.Tests\JMWToolkit.Tests.csproj", "{C4DC460B-3CE6-4EDC-8DF6-97F80367095D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JMWToolkit.Tests", "..\JMWToolkit.Tests\JMWToolkit.Tests.csproj", "{C4DC460B-3CE6-4EDC-8DF6-97F80367095D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/JMWToolkit/MutexHelper.cs
+++ b/JMWToolkit/MutexHelper.cs
@@ -1,14 +1,6 @@
-﻿/*
- * Copyright (c) 2023, jmwileydev@gmail.com
-All rights reserved.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree. 
-*/
-using System;
+﻿using System;
 using System.Threading;
 
-namespace JMWToolkit;
 
 /// <summary>
 /// This class is used to help with making sure ReleaseMutex is called when the scope of
@@ -25,7 +17,6 @@ namespace JMWToolkit;
 /// </summary>
 public class MutexHelper : IDisposable
 {
-
     private readonly Mutex _mutex;
     private bool _ownsMutex;
     private bool disposedValue = false;
@@ -77,7 +68,8 @@ public class MutexHelper : IDisposable
             throw new InvalidOperationException("MutexHelper already owns the mutex");
         }
 
-        _mutex.Dispose();
+        _ownsMutex = false;
+        _mutex.ReleaseMutex();
     }
 
     protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
- Add an optional bool to the constructor so the user can create the AsyncLock locked w/o doing a Wait.
- Add a static method Task<AsyncLockHelper> CreateAsyncLockHelperAsync(AsyncLock asyncLock) to AsyncLockHelper to allow a caller to asynchronously wait for the AsyncLock.
- Update to .Net 8